### PR TITLE
feat/M3-14(Criar regras para persistir os dados em um arquivo) :sparkles: 

### DIFF
--- a/ProductEntityRepository.txt
+++ b/ProductEntityRepository.txt
@@ -1,0 +1,2 @@
+7812c39f-1b3c-4419-8666-d02b15913228;Teste;10.0;disable
+04dfd14a-80fb-49d8-a658-c62938263110;Produto;15.0;enable

--- a/README.md
+++ b/README.md
@@ -307,6 +307,108 @@ ProductWriter  ..>  ProductContract
 #### CLI
 
 ```mermaid
+classDiagram
+direction BT
+class Application {
+  + Application() 
+  + main(String[]) void
+}
+class Entity~T~ {
+<<Interface>>
+  + serialize() String
+  + deserialize(String[]) T
+}
+class Menu {
+  + Menu() 
+  - ProductEntityService productEntityService
+  - String MENU_DIVIDER
+  - String NEW_LINE
+  - String SINGLE_OPTION
+  - String MENU_MESSAGE
+  - String MENU_OPTION_SEPARATOR
+  - int MENU_DIVIDER_SIZE
+  - String TOTAL_OPTIONS
+  + displayMenu() void
+  - optionBuilder(Scanner, String[]) int
+}
+class ProductEntity {
+  + ProductEntity(String, String, ProductStatus, Double) 
+  + ProductEntity() 
+  - String id
+  + String FIELD_SEPARATOR
+  - ProductStatus status
+  - String productName
+  - Double productPrice
+  + serialize() String
+  + deserialize(String[]) ProductEntity
+  + toString() String
+  + getProductPrice() Double
+  + getStatus() ProductStatus
+  + getId() String
+  + getProductName() String
+}
+class ProductEntityDTO {
+  + ProductEntityDTO(String, String, ProductStatus, Double) 
+  + ProductEntityDTO() 
+  - String id
+  - String productName
+  - Double productPrice
+  - ProductStatus status
+  + getStatus() ProductStatus
+  + getId() String
+  + getProductPrice() Double
+  + getProductName() String
+  + toString() String
+}
+class ProductEntityRepository {
+<<Interface>>
+
+}
+class ProductEntityRepositoryImpl {
+  + ProductEntityRepositoryImpl() 
+  - String FILE_PATH
+  + save(ProductContract) ProductContract
+  + get(String) ProductContract
+}
+class ProductEntityService {
+<<Interface>>
+  + get(String) ProductEntityDTO
+  + enable(String) ProductEntityDTO
+  + create(String, Double) ProductEntityDTO
+  + disable(String) ProductEntityDTO
+}
+class ProductServiceImpl {
+  + ProductServiceImpl() 
+  - ProductEntityRepository repository
+  + disable(String) ProductEntityDTO
+  + create(String, Double) ProductEntityDTO
+  + get(String) ProductEntityDTO
+  + enable(String) ProductEntityDTO
+}
+class QuestionHandler {
+<<enumeration>>
+  + QuestionHandler() 
+  +  INTEGER
+  +  DOUBLE
+  - String QUESTION_FORMAT
+  +  STRING
+  + response(Scanner, String) Object
+}
+
+Application  ..>  Menu 
+Menu  ..>  ProductEntityDTO 
+Menu "1" *--> "productEntityService 1" ProductEntityService 
+Menu  ..>  ProductServiceImpl 
+Menu  ..>  QuestionHandler 
+ProductEntity  ..>  Entity~T~ 
+ProductEntityRepositoryImpl  ..>  ProductEntity 
+ProductEntityRepositoryImpl  ..>  ProductEntityRepository 
+ProductEntityService  ..>  ProductEntityDTO 
+ProductServiceImpl  ..>  ProductEntity 
+ProductServiceImpl  ..>  ProductEntityDTO 
+ProductServiceImpl "1" *--> "repository 1" ProductEntityRepository 
+ProductServiceImpl  ..>  ProductEntityRepositoryImpl 
+ProductServiceImpl  ..>  ProductEntityService 
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ ProductEntityService  ..>  ProductResponse
 ProductEntityServiceContract  ..>  ProductRequest 
 ProductEntityServiceContract  ..>  ProductResponse 
 ProductRepository  ..>  ProductEntity 
-
 ```
 
 ---
@@ -181,8 +180,6 @@ class ExceptionHandler {
   +  PRODUCT_STATUS_SHOULD_NOT_BE_NULL
   + getMessage() String
   + getMessage(String) String
-  + values() ExceptionHandler[]
-  + valueOf(String) ExceptionHandler
 }
 class MapperFailureException {
   + MapperFailureException(ExceptionHandler, String) 
@@ -264,9 +261,7 @@ class ProductStatus {
   + ProductStatus() 
   +  ENABLE
   +  DISABLE
-  + valueOf(String) ProductStatus
   + toString() String
-  + values() ProductStatus[]
 }
 class ProductWriter {
 <<Interface>>
@@ -306,7 +301,6 @@ ProductService  ..>  ProductWriter
 ProductServiceContract  ..>  ProductContract 
 ProductServiceContract  ..>  ProductException 
 ProductWriter  ..>  ProductContract 
-
 ```
 
 ---

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/enums/QuestionHandler.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/enums/QuestionHandler.java
@@ -16,6 +16,7 @@ public enum QuestionHandler{
     DOUBLE {
         @Override
         public Object response(Scanner scanner, String question) {
+            scanner.nextLine();
             Double value = 0.0;
             System.out.printf(QUESTION_FORMAT, question);
             try {
@@ -30,6 +31,7 @@ public enum QuestionHandler{
     INTEGER {
         @Override
         public Object response(Scanner scanner, String question) {
+            scanner.nextLine();
             Integer value = 0;
             System.out.printf(QUESTION_FORMAT, question);
             try {

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/model/ProductEntity.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/model/ProductEntity.java
@@ -1,11 +1,11 @@
 package diegosneves.github.hexagonal.adapters.cli.model;
 
+import diegosneves.github.hexagonal.adapters.cli.repository.Entity;
 import diegosneves.github.hexagonal.app.enums.ProductStatus;
 
-import java.io.Serializable;
+public class ProductEntity implements Entity<ProductEntity> {
 
-public class ProductEntity implements Serializable {
-
+    public static final String FIELD_SEPARATOR = ";";
     private String id;
     private String productName;
     private ProductStatus status;
@@ -36,6 +36,7 @@ public class ProductEntity implements Serializable {
     public Double getProductPrice() {
         return this.productPrice;
     }
+
 
     public static class Builder {
         private String id;
@@ -69,6 +70,21 @@ public class ProductEntity implements Serializable {
         public ProductEntity build() {
             return new ProductEntity(this.id, this.productName, this.status, this.productPrice);
         }
+    }
+
+    @Override
+    public String serialize() {
+        return String.format("%s%s%s%s%s%s%s", this.id, FIELD_SEPARATOR, this.productName, FIELD_SEPARATOR, this.productPrice, FIELD_SEPARATOR, this.status);
+    }
+
+    @Override
+    public ProductEntity deserialize(String... inputDateForDeserialization) {
+        return new Builder()
+                .id(inputDateForDeserialization[0])
+                .productName(inputDateForDeserialization[1])
+                .productPrice(Double.valueOf(inputDateForDeserialization[2]))
+                .status(ProductStatus.valueOf(inputDateForDeserialization[3].toUpperCase()))
+                .build();
     }
 
     @Override

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/Entity.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/Entity.java
@@ -1,0 +1,11 @@
+package diegosneves.github.hexagonal.adapters.cli.repository;
+
+import java.io.Serializable;
+
+public interface Entity <T> extends Serializable {
+
+    String serialize();
+
+    T deserialize(String... inputDateForDeserialization);
+
+}

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/ProductEntityRepository.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/ProductEntityRepository.java
@@ -1,0 +1,7 @@
+package diegosneves.github.hexagonal.adapters.cli.repository;
+
+import diegosneves.github.hexagonal.app.repository.ProductPersistenceContract;
+
+public interface ProductEntityRepository extends ProductPersistenceContract {
+
+}

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/impl/ProductEntityRepositoryImpl.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/impl/ProductEntityRepositoryImpl.java
@@ -1,0 +1,27 @@
+package diegosneves.github.hexagonal.adapters.cli.repository.impl;
+
+import diegosneves.github.hexagonal.adapters.cli.repository.ProductEntityRepository;
+import diegosneves.github.hexagonal.app.domain.product.entity.ProductContract;
+import diegosneves.github.hexagonal.app.exceptions.ProductException;
+import diegosneves.github.hexagonal.app.exceptions.handler.ExceptionHandler;
+
+import static java.util.Objects.isNull;
+
+public class ProductEntityRepositoryImpl implements ProductEntityRepository {
+
+    @Override
+    public ProductContract get(String id) {
+        if (isNull(id) || id.trim().isBlank() ) {
+            throw new ProductException(ExceptionHandler.PRODUCT_ID_SHOULD_NOT_BE_NULL_OR_EMPTY);
+        }
+        return null;
+    }
+
+    @Override
+    public ProductContract save(ProductContract product) {
+        if (isNull(product)) {
+            throw new ProductException(ExceptionHandler.PRODUCT_SHOULD_NOT_BE_NULL);
+        }
+        return null;
+    }
+}

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/impl/ProductEntityRepositoryImpl.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/repository/impl/ProductEntityRepositoryImpl.java
@@ -1,18 +1,47 @@
 package diegosneves.github.hexagonal.adapters.cli.repository.impl;
 
+import diegosneves.github.hexagonal.adapters.cli.model.ProductEntity;
 import diegosneves.github.hexagonal.adapters.cli.repository.ProductEntityRepository;
+import diegosneves.github.hexagonal.app.domain.product.entity.Product;
 import diegosneves.github.hexagonal.app.domain.product.entity.ProductContract;
 import diegosneves.github.hexagonal.app.exceptions.ProductException;
 import diegosneves.github.hexagonal.app.exceptions.handler.ExceptionHandler;
+import diegosneves.github.hexagonal.app.mapper.MapperStrategy;
+import diegosneves.github.hexagonal.app.mapper.ProductByCliEntityMapper;
+import diegosneves.github.hexagonal.app.mapper.ProductEntityCLIMapper;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.util.Objects.isNull;
 
 public class ProductEntityRepositoryImpl implements ProductEntityRepository {
 
+    private static final String FILE_PATH = "ProductEntityRepository.txt";
+
     @Override
     public ProductContract get(String id) {
-        if (isNull(id) || id.trim().isBlank() ) {
+        if (isNull(id) || id.trim().isBlank()) {
             throw new ProductException(ExceptionHandler.PRODUCT_ID_SHOULD_NOT_BE_NULL_OR_EMPTY);
+        }
+        MapperStrategy<Product, ProductEntity> mapperStrategy = new ProductByCliEntityMapper();
+        ProductEntity productEntity = new ProductEntity();
+        try (BufferedReader reader = new BufferedReader(new FileReader(FILE_PATH))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] productData = line.split(ProductEntity.FIELD_SEPARATOR);
+                if (productData[0].equals(id.trim())) {
+                    productEntity = productEntity.deserialize(productData);
+                    return mapperStrategy.mapper(productEntity);
+                }
+            }
+        } catch (IOException e) {
+            System.out.printf("Falha ao ler o arquivo: \n%s", e.getMessage());
         }
         return null;
     }
@@ -22,6 +51,31 @@ public class ProductEntityRepositoryImpl implements ProductEntityRepository {
         if (isNull(product)) {
             throw new ProductException(ExceptionHandler.PRODUCT_SHOULD_NOT_BE_NULL);
         }
-        return null;
+
+        MapperStrategy<ProductEntity, ProductContract> mapperStrategy = new ProductEntityCLIMapper();
+        List<ProductEntity> productList = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(FILE_PATH))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                ProductEntity entity = new ProductEntity().deserialize(line.split(ProductEntity.FIELD_SEPARATOR));
+                productList.add(entity);
+            }
+            productList.removeIf(e -> e.getId().equals(product.getId()));
+        } catch (IOException e) {
+            System.out.printf("Falha ao ler o arquivo: \n%s", e.getMessage());
+        }
+        productList.add(mapperStrategy.mapper(product));
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(FILE_PATH, false))) {
+            for (ProductEntity entity : productList) {
+                writer.write(entity.serialize());
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            System.out.printf("Falha ao escrever no arquivo: \n%s", e.getMessage());
+        }
+
+        return product;
     }
 }

--- a/src/main/java/diegosneves/github/hexagonal/adapters/cli/service/impl/ProductServiceImpl.java
+++ b/src/main/java/diegosneves/github/hexagonal/adapters/cli/service/impl/ProductServiceImpl.java
@@ -1,28 +1,71 @@
 package diegosneves.github.hexagonal.adapters.cli.service.impl;
 
 import diegosneves.github.hexagonal.adapters.cli.dto.ProductEntityDTO;
+import diegosneves.github.hexagonal.adapters.cli.model.ProductEntity;
+import diegosneves.github.hexagonal.adapters.cli.repository.ProductEntityRepository;
+import diegosneves.github.hexagonal.adapters.cli.repository.impl.ProductEntityRepositoryImpl;
 import diegosneves.github.hexagonal.adapters.cli.service.ProductEntityService;
+import diegosneves.github.hexagonal.app.domain.product.entity.ProductContract;
+import diegosneves.github.hexagonal.app.domain.product.factory.ProductFactory;
 import diegosneves.github.hexagonal.app.exceptions.ProductException;
+import diegosneves.github.hexagonal.app.exceptions.handler.ExceptionHandler;
+import diegosneves.github.hexagonal.app.mapper.BuilderMapper;
+import diegosneves.github.hexagonal.app.mapper.MapperStrategy;
+import diegosneves.github.hexagonal.app.mapper.ProductEntityCLIMapper;
 
 public class ProductServiceImpl implements ProductEntityService {
 
+    private final ProductEntityRepository repository;
+
+    public ProductServiceImpl() {
+        this.repository = new ProductEntityRepositoryImpl();
+    }
+
     @Override
     public ProductEntityDTO get(String id) throws ProductException {
-        return null;
+        ProductContract productContract = this.repository.get(id.trim());
+        if (productContract == null) {
+            throw new ProductException(ExceptionHandler.PRODUCT_NOT_FOUND, id);
+        }
+        MapperStrategy<ProductEntity, ProductContract> mapperStrategy = new ProductEntityCLIMapper();
+        ProductEntity productEntity = BuilderMapper.builderMapper(ProductEntity.class, productContract, mapperStrategy);
+
+        return BuilderMapper.builderMapper(ProductEntityDTO.class, productEntity);
     }
 
     @Override
     public ProductEntityDTO create(String productName, Double productPrice) {
-        return null;
+        ProductContract newProduct = ProductFactory.create(productName, productPrice);
+        ProductContract createdProduct = this.repository.save(newProduct);
+        MapperStrategy<ProductEntity, ProductContract> mapperStrategy = new ProductEntityCLIMapper();
+        ProductEntity productEntity = mapperStrategy.mapper(createdProduct);
+
+        return BuilderMapper.builderMapper(ProductEntityDTO.class, productEntity);
     }
 
     @Override
     public ProductEntityDTO enable(String id) {
-        return null;
+        ProductContract productContract = this.repository.get(id.trim());
+        if (productContract == null) {
+            throw new ProductException(ExceptionHandler.PRODUCT_NOT_FOUND, id);
+        }
+        productContract.enable();
+        ProductContract updatedProduct = this.repository.save(productContract);
+        MapperStrategy<ProductEntity, ProductContract> mapperStrategy = new ProductEntityCLIMapper();
+        ProductEntity productEntity = mapperStrategy.mapper(updatedProduct);
+        return BuilderMapper.builderMapper(ProductEntityDTO.class, productEntity);
     }
 
     @Override
     public ProductEntityDTO disable(String id) {
-        return null;
+        ProductContract productContract = this.repository.get(id.trim());
+        if (productContract == null) {
+            throw new ProductException(ExceptionHandler.PRODUCT_NOT_FOUND, id);
+        }
+        productContract.disable();
+        ProductContract updatedProduct = this.repository.save(productContract);
+        MapperStrategy<ProductEntity, ProductContract> mapperStrategy = new ProductEntityCLIMapper();
+        ProductEntity productEntity = mapperStrategy.mapper(updatedProduct);
+        return BuilderMapper.builderMapper(ProductEntityDTO.class, productEntity);
     }
 }

--- a/src/main/java/diegosneves/github/hexagonal/app/exceptions/handler/ExceptionHandler.java
+++ b/src/main/java/diegosneves/github/hexagonal/app/exceptions/handler/ExceptionHandler.java
@@ -9,7 +9,7 @@ package diegosneves.github.hexagonal.app.exceptions.handler;
  */
 public enum ExceptionHandler {
 
-    PRICE_LESS_THAN_ZERO("O preço do Produto deve ser igual ou maior que zero"),
+    PRICE_LESS_THAN_ZERO("O preço do Produto deve ser maior que zero"),
     PRICE_EQUAL_OR_LESS_THAN_ZERO("O preço do Produto deve ser igual ou menor que zero"),
     PRODUCT_ID_SHOULD_NOT_BE_NULL_OR_EMPTY("O ID do Produto não deve ser vazio ou nulo"),
     PRODUCT_NAME_SHOULD_NOT_BE_NULL_OR_EMPTY("O Nome do Produto não deve ser vazio ou nulo"),

--- a/src/main/java/diegosneves/github/hexagonal/app/mapper/ProductByCliEntityMapper.java
+++ b/src/main/java/diegosneves/github/hexagonal/app/mapper/ProductByCliEntityMapper.java
@@ -1,0 +1,24 @@
+package diegosneves.github.hexagonal.app.mapper;
+
+import diegosneves.github.hexagonal.adapters.cli.model.ProductEntity;
+import diegosneves.github.hexagonal.app.domain.product.entity.Product;
+
+import java.lang.reflect.Field;
+
+public class ProductByCliEntityMapper implements MapperStrategy<Product, ProductEntity> {
+
+    private static final String STATUS_FIELD = "status";
+
+    @Override
+    public Product mapper(ProductEntity origin) {
+        Product product = new Product(origin.getId(), origin.getProductName(), origin.getProductPrice());
+        try {
+            Field field = Product.class.getDeclaredField(STATUS_FIELD);
+            field.setAccessible(true);
+            field.set(product, origin.getStatus());
+        } catch (NoSuchFieldException | IllegalAccessException ignored) {
+
+        }
+        return product;
+    }
+}

--- a/src/main/java/diegosneves/github/hexagonal/app/mapper/ProductEntityCLIMapper.java
+++ b/src/main/java/diegosneves/github/hexagonal/app/mapper/ProductEntityCLIMapper.java
@@ -1,0 +1,17 @@
+package diegosneves.github.hexagonal.app.mapper;
+
+import diegosneves.github.hexagonal.adapters.cli.model.ProductEntity;
+import diegosneves.github.hexagonal.app.domain.product.entity.ProductContract;
+
+public class ProductEntityCLIMapper implements MapperStrategy<ProductEntity, ProductContract> {
+
+    @Override
+    public ProductEntity mapper(ProductContract origin) {
+        return new ProductEntity.Builder()
+                .id(origin.getId())
+                .productName(origin.getName())
+                .productPrice(origin.getPrice())
+                .status(origin.getStatus())
+                .build();
+    }
+}

--- a/src/test/java/diegosneves/github/hexagonal/adapters/cli/service/impl/ProductServiceImplTest.java
+++ b/src/test/java/diegosneves/github/hexagonal/adapters/cli/service/impl/ProductServiceImplTest.java
@@ -1,0 +1,192 @@
+package diegosneves.github.hexagonal.adapters.cli.service.impl;
+
+import diegosneves.github.hexagonal.adapters.cli.dto.ProductEntityDTO;
+import diegosneves.github.hexagonal.adapters.cli.repository.impl.ProductEntityRepositoryImpl;
+import diegosneves.github.hexagonal.app.domain.product.entity.Product;
+import diegosneves.github.hexagonal.app.domain.product.entity.ProductContract;
+import diegosneves.github.hexagonal.app.enums.ProductStatus;
+import diegosneves.github.hexagonal.app.exceptions.ProductException;
+import diegosneves.github.hexagonal.app.exceptions.handler.ExceptionHandler;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProductServiceImplTest {
+
+    private static final String PRODUCT_ID = "0ed6e6a1-882c-4d2d-83ee-67034ee1ab9f";
+
+    private ProductServiceImpl service;
+
+    ProductEntityRepositoryImpl repository;
+
+    ArgumentCaptor<ProductContract> productContractCaptor = ArgumentCaptor.forClass(ProductContract.class);
+
+    private Product product;
+
+    @BeforeEach
+    @SneakyThrows
+    void setUp() {
+        this.service = new ProductServiceImpl();
+        this.repository = Mockito.mock(ProductEntityRepositoryImpl.class);
+        Field field = this.service.getClass().getDeclaredField("repository");
+        field.setAccessible(true);
+        field.set(this.service, repository);
+
+        this.product = new Product(PRODUCT_ID, "Product", 10.0);
+    }
+
+    @Test
+    void shouldReturnValidProductEntityDTOWhenGivenValidId() {
+        when(this.repository.get(PRODUCT_ID)).thenReturn(this.product);
+        ProductEntityDTO result = this.service.get(PRODUCT_ID);
+
+        assertNotNull(result);
+        assertEquals(PRODUCT_ID, result.getId());
+        assertEquals("Product", result.getProductName());
+        assertEquals(ProductStatus.DISABLE, result.getStatus());
+        assertEquals(10.0, result.getProductPrice());
+    }
+
+
+    @Test
+    void shouldThrowProductExceptionOnRetrievalWithIdInvalid() {
+        String id = "123";
+        when(this.repository.get(id)).thenReturn(null);
+
+        ProductException result = assertThrows(ProductException.class, () -> this.service.get(id));
+
+        assertNotNull(result);
+        assertEquals(ExceptionHandler.PRODUCT_NOT_FOUND.getMessage(id), result.getMessage());
+    }
+
+    @Test
+    void shouldCreateProductGivenValidNameAndPrice() {
+        double productPrice = this.product.getPrice();
+        String productNameString = "Product";
+        when(this.repository.save(any(ProductContract.class))).thenReturn(this.product);
+
+        ProductEntityDTO result = this.service.create(productNameString, productPrice);
+
+        verify(this.repository, times(1)).save(this.productContractCaptor.capture());
+
+        assertNotNull(result);
+        assertEquals(PRODUCT_ID, result.getId());
+        assertEquals(productNameString, result.getProductName());
+        assertEquals(ProductStatus.DISABLE, result.getStatus());
+        assertEquals(productPrice, result.getProductPrice());
+        ProductContract actual = this.productContractCaptor.getValue();
+        assertNotNull(actual);
+        assertTrue(isValidUUID(actual.getId()));
+        assertEquals(productNameString, actual.getName());
+        assertEquals(ProductStatus.DISABLE, actual.getStatus());
+        assertEquals(productPrice, actual.getPrice());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingProductWithNegativePrice() {
+        ProductException result = assertThrows(ProductException.class, () -> this.service.create("Product", -10.0));
+
+        verify(this.repository, never()).save(any(ProductContract.class));
+
+        assertNotNull(result);
+        assertEquals(ExceptionHandler.PRICE_LESS_THAN_ZERO.getMessage(), result.getMessage());
+    }
+
+    private Boolean isValidUUID(String id) throws ProductException {
+        try {
+            UUID.fromString(id);
+            return Boolean.TRUE;
+        } catch (IllegalArgumentException ignored) {
+            return Boolean.FALSE;
+        }
+    }
+
+    @Test
+    void shouldEnableProductGivenValidId() {
+        when(this.repository.get(PRODUCT_ID)).thenReturn(this.product);
+        when(this.repository.save(this.product)).thenReturn(this.product);
+
+        ProductEntityDTO result = this.service.enable(PRODUCT_ID);
+
+        verify(this.repository, times(1)).save(this.productContractCaptor.capture());
+
+        assertNotNull(result);
+        assertEquals(PRODUCT_ID, result.getId());
+        assertEquals("Product", result.getProductName());
+        assertEquals(ProductStatus.ENABLE, result.getStatus());
+        assertEquals(10.0, result.getProductPrice());
+        ProductContract actual = this.productContractCaptor.getValue();
+        assertNotNull(actual);
+        assertEquals(PRODUCT_ID, actual.getId());
+        assertEquals("Product", actual.getName());
+        assertEquals(ProductStatus.ENABLE, actual.getStatus());
+        assertEquals(10.0, actual.getPrice());
+    }
+
+    @Test
+    void shouldThrowProductExceptionWhenEnablingNonExistentProductGivenInvalidId() {
+        String id = "123";
+        when(this.repository.get(id)).thenReturn(null);
+
+        ProductException result = assertThrows(ProductException.class, () -> this.service.enable(id));
+
+        assertNotNull(result);
+        assertEquals(ExceptionHandler.PRODUCT_NOT_FOUND.getMessage(id), result.getMessage());
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldDisableProductGivenValidId() {
+        this.product.enable();
+        Field field = this.product.getClass().getDeclaredField("productPrice");
+        field.setAccessible(true);
+        field.set(this.product, 0.0);
+        when(this.repository.get(PRODUCT_ID)).thenReturn(this.product);
+        when(this.repository.save(this.product)).thenReturn(this.product);
+
+        ProductEntityDTO result = this.service.disable(PRODUCT_ID);
+
+        verify(this.repository, times(1)).save(this.productContractCaptor.capture());
+
+        assertNotNull(result);
+        assertEquals(PRODUCT_ID, result.getId());
+        assertEquals("Product", result.getProductName());
+        assertEquals(ProductStatus.DISABLE, result.getStatus());
+        assertEquals(0.0, result.getProductPrice());
+        ProductContract actual = this.productContractCaptor.getValue();
+        assertNotNull(actual);
+        assertEquals(PRODUCT_ID, actual.getId());
+        assertEquals("Product", actual.getName());
+        assertEquals(ProductStatus.DISABLE, actual.getStatus());
+        assertEquals(0.0, actual.getPrice());
+    }
+
+
+    @Test
+    void shouldThrowProductExceptionWhenDisablingNonExistentProductGivenInvalidId() {
+        String id = "123";
+        when(this.repository.get(id)).thenReturn(null);
+
+        ProductException result = assertThrows(ProductException.class, () -> this.service.disable(id));
+
+        assertNotNull(result);
+        assertEquals(ExceptionHandler.PRODUCT_NOT_FOUND.getMessage(id), result.getMessage());
+    }
+
+}


### PR DESCRIPTION
# Solicitação de Pull Request

## Status

- [x] In Progress
- [x] Ready to Merging

## Tipo

- [ ] Release
- [x] Feature
- [ ] Technical Debt
- [ ] Fix
- [ ] Test
- [ ] Refactor
- [ ] Documentation
- [ ] Performance

## Descrição
feat/M3-14(Criar regras para persistir os dados em um arquivo) :sparkles: Implementação de ProductEntityCLIMapper e classes relacionadas

- Implementada a classe ProductEntityCLIMapper para mapear e gerenciar a relação entre ProductEntity e ProductContract.

- Atualizada a classe ProductServiceImpl com a implementação dos métodos necessários como get(), create(), enable() e disable() para manipulação das entidades de produto.

- Adicionados casos de teste relacionados na classe ProductServiceImplTest para garantir a funcionalidade do código.

- Criadas as classes de repositório necessárias para a persistência de dados.

---

feat/M3-14(Criar regras para persistir os dados em um arquivo) :sparkles: Implementação do mapper e repositório para a entidade product

- **Implementação da classe ProductEntityCLIMapper:** Esta classe é usada para mapear 'ProductEntity' e 'ProductContract'.

- **Atualização do ProductServiceImpl:** Atualizamos a classe 'ProductServiceImpl' para incluir as operações necessárias, tais como:
  - `get()`
  - `create()`
  - `enable()`
  - `disable()`

- **Criação de classes repositórias relacionadas:** Estas classes são usadas para persistência de dados.

- **Adição de testes no ProductServiceImplTest:** Testes foram adicionados para validar as implementações.

---